### PR TITLE
Change from 'lodash/isempty' to 'lodash/isEmpty'

### DIFF
--- a/src/components/background/panel.js
+++ b/src/components/background/panel.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import isEmpty from 'lodash/isempty';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
`'lodash/isempty'` causes `npm start` to fail. It looks like on UNIX like systems (e.g. Linux) this needs to be `'lodash/isEmpty'`